### PR TITLE
Feat/#3 add i18n

### DIFF
--- a/components.json
+++ b/components.json
@@ -5,7 +5,7 @@
   "tsx": true,
   "tailwind": {
     "config": "tailwind.config.ts",
-    "css": "src/app/globals.css",
+    "css": "src/styles/globals.css",
     "baseColor": "neutral",
     "cssVariables": true,
     "prefix": ""

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,10 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next';
+import createNextIntlPlugin from 'next-intl/plugin';
+
+const withNextIntl = createNextIntlPlugin();
 
 const nextConfig: NextConfig = {
   /* config options here */
 };
 
-export default nextConfig;
+export default withNextIntl(nextConfig);

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.469.0",
     "next": "15.1.3",
+    "next-intl": "^3.26.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tailwind-merge": "^2.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       next:
         specifier: 15.1.3
         version: 15.1.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      next-intl:
+        specifier: ^3.26.3
+        version: 3.26.3(next@15.1.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
       react:
         specifier: ^19.0.0
         version: 19.0.0
@@ -133,6 +136,21 @@ packages:
   '@eslint/plugin-kit@0.2.4':
     resolution: {integrity: sha512-zSkKow6H5Kdm0ZUQUB2kV5JIXqoG0+uH5YADhaEHswm664N9Db8dXSi0nMJpacpMf+MyyglF1vnZohpEg5yUtg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@formatjs/ecma402-abstract@2.3.2':
+    resolution: {integrity: sha512-6sE5nyvDloULiyOMbOTJEEgWL32w+VHkZQs8S02Lnn8Y/O5aQhjOEXwWzvR7SsBE/exxlSpY2EsWZgqHbtLatg==}
+
+  '@formatjs/fast-memoize@2.2.6':
+    resolution: {integrity: sha512-luIXeE2LJbQnnzotY1f2U2m7xuQNj2DA8Vq4ce1BY9ebRZaoPB1+8eZ6nXpLzsxuW5spQxr7LdCg+CApZwkqkw==}
+
+  '@formatjs/icu-messageformat-parser@2.9.8':
+    resolution: {integrity: sha512-hZlLNI3+Lev8IAXuwehLoN7QTKqbx3XXwFW1jh0AdIA9XJdzn9Uzr+2LLBspPm/PX0+NLIfykj/8IKxQqHUcUQ==}
+
+  '@formatjs/icu-skeleton-parser@1.8.12':
+    resolution: {integrity: sha512-QRAY2jC1BomFQHYDMcZtClqHR55EEnB96V7Xbk/UiBodsuFc5kujybzt87+qj1KqmJozFhk6n4KiT1HKwAkcfg==}
+
+  '@formatjs/intl-localematcher@0.5.10':
+    resolution: {integrity: sha512-af3qATX+m4Rnd9+wHcjJ4w2ijq+rAVP3CCinJQvFv1kgSu1W6jypUmvleJxcewdxmutM8dmIRZFxO/IQBZmP2Q==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -725,6 +743,9 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.4.3:
+    resolution: {integrity: sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -1088,6 +1109,9 @@ packages:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
+  intl-messageformat@10.7.11:
+    resolution: {integrity: sha512-IB2N1tmI24k2EFH3PWjU7ivJsnWyLwOWOva0jnXFa29WzB6fb0JZ5EMQGu+XN5lDtjHYFo0/UooP67zBwUg7rQ==}
+
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
@@ -1338,6 +1362,16 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
+  next-intl@3.26.3:
+    resolution: {integrity: sha512-6Y97ODrDsEE1J8cXKMHwg1laLdtkN66QMIqG8BzH4zennJRUNTtM8UMtBDyhfmF6uiZ+xsbWLXmHUgmUymUsfQ==}
+    peerDependencies:
+      next: ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
 
   next@15.1.3:
     resolution: {integrity: sha512-5igmb8N8AEhWDYzogcJvtcRDU6n4cMGtBklxKD4biYv4LXN8+awc/bbQ2IM2NQHdVPgJ6XumYXfo3hBtErg1DA==}
@@ -1919,6 +1953,11 @@ packages:
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
+  use-intl@3.26.3:
+    resolution: {integrity: sha512-yY0a2YseO17cKwHA9M6fcpiEJ2Uo81DEU0NOUxNTp6lJVNOuI6nULANPVVht6IFdrYFtlsMmMoc97+Eq9/Tnng==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -2046,6 +2085,32 @@ snapshots:
   '@eslint/plugin-kit@0.2.4':
     dependencies:
       levn: 0.4.1
+
+  '@formatjs/ecma402-abstract@2.3.2':
+    dependencies:
+      '@formatjs/fast-memoize': 2.2.6
+      '@formatjs/intl-localematcher': 0.5.10
+      decimal.js: 10.4.3
+      tslib: 2.8.1
+
+  '@formatjs/fast-memoize@2.2.6':
+    dependencies:
+      tslib: 2.8.1
+
+  '@formatjs/icu-messageformat-parser@2.9.8':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.2
+      '@formatjs/icu-skeleton-parser': 1.8.12
+      tslib: 2.8.1
+
+  '@formatjs/icu-skeleton-parser@1.8.12':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.2
+      tslib: 2.8.1
+
+  '@formatjs/intl-localematcher@0.5.10':
+    dependencies:
+      tslib: 2.8.1
 
   '@humanfs/core@0.19.1': {}
 
@@ -2633,6 +2698,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decimal.js@10.4.3: {}
+
   deep-is@0.1.4: {}
 
   define-data-property@1.1.4:
@@ -3150,6 +3217,13 @@ snapshots:
       hasown: 2.0.2
       side-channel: 1.1.0
 
+  intl-messageformat@10.7.11:
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.2
+      '@formatjs/fast-memoize': 2.2.6
+      '@formatjs/icu-messageformat-parser': 2.9.8
+      tslib: 2.8.1
+
   is-array-buffer@3.0.5:
     dependencies:
       call-bind: 1.0.8
@@ -3409,6 +3483,16 @@ snapshots:
   nanoid@3.3.8: {}
 
   natural-compare@1.4.0: {}
+
+  negotiator@1.0.0: {}
+
+  next-intl@3.26.3(next@15.1.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0):
+    dependencies:
+      '@formatjs/intl-localematcher': 0.5.10
+      negotiator: 1.0.0
+      next: 15.1.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
+      use-intl: 3.26.3(react@19.0.0)
 
   next@15.1.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
@@ -4027,6 +4111,12 @@ snapshots:
     dependencies:
       querystringify: 2.2.0
       requires-port: 1.0.0
+
+  use-intl@3.26.3(react@19.0.0):
+    dependencies:
+      '@formatjs/fast-memoize': 2.2.6
+      intl-messageformat: 10.7.11
+      react: 19.0.0
 
   util-deprecate@1.0.2: {}
 

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,6 +1,7 @@
 import { notFound } from 'next/navigation';
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages } from 'next-intl/server';
+import { ReactNode } from 'react';
 import { routing } from '@/i18n/routing';
 
 type Params = Promise<{ locale: never }>;
@@ -9,7 +10,7 @@ export default async function LocaleLayout({
   children,
   params,
 }: {
-  children: React.ReactNode;
+  children: ReactNode;
   params: Params;
 }) {
   const { locale } = await params;

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,0 +1,31 @@
+import { notFound } from 'next/navigation';
+import { NextIntlClientProvider } from 'next-intl';
+import { getMessages } from 'next-intl/server';
+import { routing } from '@/i18n/routing';
+
+type Params = Promise<{ locale: never }>;
+
+export default async function LocaleLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Params;
+}) {
+  const { locale } = await params;
+  // https://nextjs.org/docs/messages/sync-dynamic-apis
+
+  if (!routing.locales.includes(locale)) {
+    notFound();
+  }
+
+  const messages = await getMessages();
+
+  return (
+    <html lang={locale}>
+      <NextIntlClientProvider messages={messages}>
+        <body>{children}</body>
+      </NextIntlClientProvider>
+    </html>
+  );
+}

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -2,6 +2,8 @@
 
 import { useQuery } from '@tanstack/react-query';
 import Image from 'next/image';
+import { useTranslations } from 'next-intl';
+import { LanguageSwitcher } from '@/components/logic/switch/LanguageSwitcher';
 
 const fetchUser = async (): Promise<{ id: string }> => {
   const res = await fetch('/api/user');
@@ -11,15 +13,40 @@ const fetchUser = async (): Promise<{ id: string }> => {
   return res.json();
 };
 
+const CODE_PATH = 'src/app/[locale]/page.tsx';
+
 export default function Home() {
-  const { data: user } = useQuery<{ id: string }, Error>({
+  const t = useTranslations('Home');
+  const { data: user, isLoading } = useQuery<{ id: string }, Error>({
     queryKey: ['user'],
     queryFn: fetchUser,
   });
 
   return (
-    <div className="grid min-h-screen grid-rows-[20px_1fr_20px] items-center justify-items-center gap-16 p-8 pb-20 font-[family-name:var(--font-geist-sans)] sm:p-20">
-      {JSON.stringify(user, null, 2)}
+    <div className="grid min-h-screen grid-rows-[auto_1fr_20px] items-center justify-items-center gap-16 p-8 pb-20 font-[family-name:var(--font-geist-sans)] sm:p-20">
+      <section className="flex w-full max-w-md flex-col items-center gap-6 rounded-lg bg-slate-200 p-6 shadow-md">
+        {/* Header */}
+        <h1 className="text-3xl font-bold text-gray-800">TEST AREA</h1>
+
+        {/* MSW Test Section */}
+        <div className="w-full rounded-md bg-white p-4 shadow-inner">
+          <h2 className="mb-2 text-xl font-semibold text-gray-700">
+            MSW Test:
+          </h2>
+          <pre className="overflow-auto rounded bg-gray-100 p-3 text-sm text-gray-600">
+            {isLoading ? 'loading...' : JSON.stringify(user, null, 2)}
+          </pre>
+        </div>
+
+        {/* Intl Test Section */}
+        <div className="w-full rounded-md bg-white p-4 shadow-inner">
+          <h2 className="mb-2 text-xl font-semibold text-gray-700">
+            Intl Test:
+          </h2>
+          <LanguageSwitcher />
+        </div>
+      </section>
+
       <main className="row-start-2 flex flex-col items-center gap-8 sm:items-start">
         <Image
           className="dark:invert"
@@ -31,13 +58,15 @@ export default function Home() {
         />
         <ol className="list-inside list-decimal text-center font-[family-name:var(--font-geist-mono)] text-sm sm:text-left">
           <li className="mb-2">
-            Get started by editing{' '}
-            <code className="rounded bg-black/[.05] px-1 py-0.5 font-semibold dark:bg-white/[.06]">
-              src/app/page.tsx
-            </code>
-            .
+            {t.rich('get_start', {
+              link: () => (
+                <code className="rounded bg-black/[.05] px-1 py-0.5 font-semibold dark:bg-white/[.06]">
+                  {CODE_PATH}
+                </code>
+              ),
+            })}
           </li>
-          <li>Save and see your changes instantly.</li>
+          <li>{t('hot_reload')}</li>
         </ol>
 
         <div className="flex flex-col items-center gap-4 sm:flex-row">
@@ -54,7 +83,7 @@ export default function Home() {
               width={20}
               height={20}
             />
-            Deploy now
+            {t('deploy')}
           </a>
           <a
             className="flex h-10 items-center justify-center rounded-full border border-solid border-black/[.08] px-4 text-sm transition-colors hover:border-transparent hover:bg-[#f2f2f2] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] sm:h-12 sm:min-w-44 sm:px-5 sm:text-base"
@@ -62,7 +91,7 @@ export default function Home() {
             target="_blank"
             rel="noopener noreferrer"
           >
-            Read our docs
+            {t('docs')}
           </a>
         </div>
       </main>
@@ -80,7 +109,7 @@ export default function Home() {
             width={16}
             height={16}
           />
-          Learn
+          {t('learn')}
         </a>
         <a
           className="flex items-center gap-2 hover:underline hover:underline-offset-4"
@@ -95,7 +124,7 @@ export default function Home() {
             width={16}
             height={16}
           />
-          Examples
+          {t('examples')}
         </a>
         <a
           className="flex items-center gap-2 hover:underline hover:underline-offset-4"
@@ -110,7 +139,7 @@ export default function Home() {
             width={16}
             height={16}
           />
-          Go to nextjs.org →
+          {t('go_to_nextjs')}
         </a>
       </footer>
     </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,19 +1,8 @@
 import type { Metadata } from 'next';
-import { Geist_Mono, Geist } from 'next/font/google';
-import '@/styles/globals.css';
 import { ReactNode } from 'react';
 import { MSWInitializer } from '@/components/logic/providers/MSWInitializer';
 import { ReactQueryProvider } from '@/components/logic/providers/ReactQueryProvider';
-
-const geistSans = Geist({
-  variable: '--font-geist-sans',
-  subsets: ['latin'],
-});
-
-const geistMono = Geist_Mono({
-  variable: '--font-geist-mono',
-  subsets: ['latin'],
-});
+import '@/styles/globals.css';
 
 export const metadata: Metadata = {
   title: 'Create Next App',
@@ -26,15 +15,9 @@ export default function RootLayout({
   children: ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        <ReactQueryProvider>
-          <MSWInitializer />
-          {children}
-        </ReactQueryProvider>
-      </body>
-    </html>
+    <ReactQueryProvider>
+      <MSWInitializer />
+      {children}
+    </ReactQueryProvider>
   );
 }

--- a/src/components/logic/switch/LanguageSwitcher.tsx
+++ b/src/components/logic/switch/LanguageSwitcher.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import clsx from 'clsx';
+import { Check } from 'lucide-react';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+
+export const LanguageSwitcher = () => {
+  const params = useParams();
+
+  const languages = [
+    { locale: 'ko', name: '한국어', isSelected: params.locale === 'ko' },
+    { locale: 'en', name: 'English', isSelected: params.locale === 'en' },
+  ];
+
+  return (
+    <div className="flex items-center gap-4">
+      {languages.map(({ locale, name, isSelected }) => (
+        <Link
+          key={locale}
+          href={`/${locale}`}
+          className={clsx(
+            'flex items-center gap-2 rounded px-4 py-2 text-white transition',
+            isSelected
+              ? 'bg-indigo-500 hover:bg-indigo-600'
+              : 'bg-slate-500 hover:bg-slate-600',
+          )}
+        >
+          {isSelected && <Check size={16} />}
+          {name}
+        </Link>
+      ))}
+    </div>
+  );
+};

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1,0 +1,11 @@
+{
+  "Home": {
+    "get_start": "Get started by editing <link></link>.",
+    "hot_reload": "Save and see your changes instantly.",
+    "deploy": "Deploy now",
+    "docs": "Read our docs",
+    "learn": "Learn",
+    "examples": "Examples",
+    "go_to_nextjs": "Go to nextjs.org →"
+  }
+}

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -1,0 +1,11 @@
+{
+  "Home": {
+    "get_start": "<link></link>를 편집하여 시작하기.",
+    "hot_reload": "변경 사항을 저장하고 즉시 확인할 수 있습니다.",
+    "deploy": "즉시 배포하기",
+    "docs": "문서 확인하기",
+    "learn": "배우기",
+    "examples": "더 많은 예제",
+    "go_to_nextjs": "nextjs.org로 이동하기 →"
+  }
+}

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -1,0 +1,15 @@
+import { getRequestConfig } from 'next-intl/server';
+import { routing } from './routing';
+
+export default getRequestConfig(async ({ requestLocale }) => {
+  let locale = await requestLocale;
+
+  if (!locale || !routing.locales.includes(locale as never)) {
+    locale = routing.defaultLocale;
+  }
+
+  return {
+    locale,
+    messages: (await import(`@/i18n/messages/${locale}.json`)).default,
+  };
+});

--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -1,0 +1,15 @@
+import { createNavigation } from 'next-intl/navigation';
+import { defineRouting } from 'next-intl/routing';
+
+export const routing = defineRouting({
+  locales: ['ko', 'en'],
+  defaultLocale: 'ko',
+});
+
+/**
+ * If you want i18n routing, use this instead of `next/link`.
+ * ❌ import Link from 'next/link';
+ * ✅ import { Link, redirect, usePathname, useRouter } from '@/i18n/routing';
+ */
+export const { Link, redirect, usePathname, useRouter } =
+  createNavigation(routing);

--- a/src/lib/mocks/index.ts
+++ b/src/lib/mocks/index.ts
@@ -1,7 +1,9 @@
 export const initMSW = async () => {
   if (typeof window === 'undefined') {
     const { server } = await import('./server');
-    server.listen();
+    server.listen({
+      onUnhandledRequest: 'bypass',
+    });
   } else {
     const { worker } = await import('./browser');
     worker.start({

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,8 @@
+import createMiddleware from 'next-intl/middleware';
+import { routing } from './i18n/routing';
+
+export default createMiddleware(routing);
+
+export const config = {
+  matcher: ['/', '/(ko|en)/:path*'],
+};


### PR DESCRIPTION
## I18n

### Installation

```bash
pnpm install next-intl
```

### Check point

1. Routing
```ts
import { createNavigation } from 'next-intl/navigation';
import { defineRouting } from 'next-intl/routing';

export const routing = defineRouting({
  locales: ['ko', 'en'],
  defaultLocale: 'ko',
});

/**
 * If you want i18n routing, use this instead of `next/link`.
 * ❌ import Link from 'next/link';
 * ✅ import { Link, redirect, usePathname, useRouter } from '@/i18n/routing';
 */
export const { Link, redirect, usePathname, useRouter } =
  createNavigation(routing);

// src/app/i18n/routing.ts
```

2. Rich Message

- Removed the `<Trans>` tag, which was used to render translated strings containing complex text or HTML elements.
- You must utilize the `t.rich` methods. [Docs - next-intl (Rich Text)](https://next-intl.dev/docs/usage/messages#rich-text)

```json
{
  "Home": {
    "get_start": "Get started by editing <link></link>.",
  }
}
```
```ts
{t.rich('get_start', {
  link: () => (
    <code className="rounded bg-black/[.05] px-1 py-0.5 font-semibold dark:bg-white/[.06]">
      {CODE_PATH}
    </code>
  ),
})}

// src/app/[locale]/page.tsx
```

**Reference**
- [Blog - RECODE LOG](https://recodelog.com/blog/next/internationalization#github-repository)
- [Docs - next-intl](https://next-intl.dev/docs/getting-started/app-router/with-i18n-routing)

### Issue

- The MSW library throws an error when initializing.
- This is a library issue and is registered in recent issues.
-> https://github.com/mswjs/msw/issues/2030

![image](https://github.com/user-attachments/assets/e2d06e85-21d9-4f8d-a789-6cf22d8c14fe)

